### PR TITLE
Switched to PLC4X 0.9.0-Snapshot with Cached driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
     <description>Fusion Gateway Application to fetch predefined data from PLCs</description>
 
     <properties>
-        <plc4j.version>0.8.0</plc4j.version>
+        <plc4j.version>0.9.0-SNAPSHOT</plc4j.version>
         <java.version>11</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -58,6 +58,11 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.plc4x</groupId>
+            <artifactId>plc4j-connection-cache</artifactId>
+            <version>${plc4j.version}</version>
+        </dependency>        
+        <dependency>
+            <groupId>org.apache.plc4x</groupId>
             <artifactId>plc4j-driver-s7</artifactId>
             <version>${plc4j.version}</version>
             <scope>runtime</scope>
@@ -65,6 +70,11 @@ under the License.
         <dependency>
             <groupId>org.apache.plc4x</groupId>
             <artifactId>plc4j-driver-simulated</artifactId>
+            <version>${plc4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.plc4x</groupId>
+            <artifactId>plc4j-driver-modbus</artifactId>
             <version>${plc4j.version}</version>
         </dependency>
         <dependency>
@@ -153,5 +163,19 @@ under the License.
             </snapshots>
         </repository>
     </repositories>
+
+    <!-- Make Snapshots of Apache plugins available -->
+    <pluginRepositories>
+      <pluginRepository>
+        <id>apache-snapshots</id>
+        <url>https://repository.apache.org/content/repositories/snapshots</url>
+        <releases>
+          <enabled>false</enabled>
+        </releases>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+      </pluginRepository>
+    </pluginRepositories>
 
 </project>

--- a/src/main/java/io/fusion/fusionplcdataservice/service/PlcDataService.java
+++ b/src/main/java/io/fusion/fusionplcdataservice/service/PlcDataService.java
@@ -27,7 +27,7 @@ import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.types.PlcResponseCode;
-import org.apache.plc4x.java.utils.connectionpool.PooledPlcDriverManager;
+import org.apache.plc4x.java.utils.connectionpool2.CachedDriverManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -41,13 +41,17 @@ import java.util.Map;
 @Primary
 public class PlcDataService implements MetricsPullService {
     private final PlcDriverManager plcDriverManager;
+    private final PlcDriverManager cachedDriverManager;
     private final FusionDataServiceConfig fusionDataServiceConfig;
+    private final String connString;
 
     @Autowired
     public PlcDataService(FusionDataServiceConfig fusionDataServiceConfig) {
         this.fusionDataServiceConfig = fusionDataServiceConfig;
-        // We're using the pooled version of the PlcDriverManager (This keeps the connection open)
-        this.plcDriverManager = new PooledPlcDriverManager();
+        // We're using the cached version of the PlcDriverManager (This keeps the connection open)
+        this.plcDriverManager = new PlcDriverManager();
+        this.connString = fusionDataServiceConfig.getConnectionString();
+        this.cachedDriverManager = new CachedDriverManager(connString, () -> plcDriverManager.getConnection(connString));
     }
 
     @Override
@@ -58,8 +62,7 @@ public class PlcDataService implements MetricsPullService {
             throw new JobNotFoundException();
         }
         Map<String, Object> data = new HashMap<>();
-        try (var plcConnection = plcDriverManager.getConnection(
-                fusionDataServiceConfig.getConnectionString())) {
+        try (var plcConnection = cachedDriverManager.getConnection(connString)) {
             // First check we have a configuration for the given job id.
             final List<FieldSpec> fieldSpecs =
                     jobSpec.getFields();

--- a/src/main/java/io/fusion/fusionplcdataservice/service/PlcDataService.java
+++ b/src/main/java/io/fusion/fusionplcdataservice/service/PlcDataService.java
@@ -51,7 +51,8 @@ public class PlcDataService implements MetricsPullService {
         // We're using the cached version of the PlcDriverManager (This keeps the connection open)
         this.plcDriverManager = new PlcDriverManager();
         this.connString = fusionDataServiceConfig.getConnectionString();
-        this.cachedDriverManager = new CachedDriverManager(connString, () -> plcDriverManager.getConnection(connString));
+        this.cachedDriverManager = new CachedDriverManager(
+        connString, () -> plcDriverManager.getConnection(connString));
     }
 
     @Override


### PR DESCRIPTION
The pooled driver doesn't work, if the PLC is switched off and on again. The cached driver solves this problem